### PR TITLE
Use elgg_get_config() instead of the $CONFIG variable.

### DIFF
--- a/actions/plugins/admin/combine.php
+++ b/actions/plugins/admin/combine.php
@@ -3,8 +3,6 @@
  * Action for combining two plugin projects
  */
 
-global $CONFIG;
-
 $old_guid = (int)get_input('old_guid');
 $new_guid = (int)get_input('new_guid');
 
@@ -35,7 +33,8 @@ foreach ($releases as $release) {
 // move download count to new project
 $annotation_name = get_metastring_id('download', TRUE);
 if ($annotation_name) {
-	$query = "UPDATE {$CONFIG->dbprefix}annotations
+	$dbprefix = elgg_get_config('dbprefix');
+	$query = "UPDATE {$dbprefix}annotations
 		SET entity_guid=$new_project->guid
 		WHERE entity_guid=$old_project->guid AND name_id=$annotation_name";
 	update_data($query);

--- a/actions/plugins/admin/upgrade.php
+++ b/actions/plugins/admin/upgrade.php
@@ -5,7 +5,8 @@
 
 set_time_limit(0);
 
-require_once "{$CONFIG->pluginspath}community_plugins/version.php";
+$plugins_path = elgg_get_plugins_path();
+require_once "{$plugins_path}community_plugins/version.php";
 
 $local_version = elgg_get_plugin_setting('version', 'community_plugins');
 
@@ -14,7 +15,7 @@ if ($version <= $local_version) {
 	forward(REFERER);
 }
 
-$base_dir = $CONFIG->pluginspath . 'community_plugins/upgrades';
+$base_dir = "{$plugins_path}community_plugins/upgrades";
 
 // taken from engine/lib/version.php
 if ($handle = opendir($base_dir)) {

--- a/actions/plugins/create_project.php
+++ b/actions/plugins/create_project.php
@@ -37,7 +37,8 @@ if (!$title) {
 	register_error(elgg_echo('plugins:error:notitle'));
 	forward(REFERER);
 }
-if ($license == 'none' || !array_key_exists($license, $CONFIG->gpllicenses)) {
+$licenses = elgg_get_config('gpllicenses');
+if ($license == 'none' || !array_key_exists($license, $licenses)) {
 	register_error(elgg_echo('plugins:error:badlicense'));
 	forward(REFERER);
 }

--- a/actions/plugins/save_project.php
+++ b/actions/plugins/save_project.php
@@ -4,7 +4,6 @@
  */
 
 elgg_make_sticky_form('community_plugins');
-global $CONFIG;
 
 // Get variables
 $title = strip_tags(get_input("title"));
@@ -34,11 +33,11 @@ if (!$title) {
 	register_error(elgg_echo('plugins:error:notitle'));
 	forward(REFERER);
 }
-if ($license == 'none' || !array_key_exists($license, $CONFIG->gpllicenses)) {
+$licenses = elgg_get_config('gpllicenses');
+if ($license == 'none' || !array_key_exists($license, $licenses)) {
 	register_error(elgg_echo('plugins:error:badlicense'));
 	forward(REFERER);
 }
-
 
 if (!$plugin_project->canEdit()) {
 	register_error(elgg_echo('plugins:error:permissions'));


### PR DESCRIPTION
In Elgg 1.9 $CONFIG variable isn't automatically available for actions anymore so use elgg_get_config() instead.

Some of the actions are completely broken without this fix. Some are working but I changed them to use elgg_get_config() anyway.
