### PR TITLE
Corrected redirection loop bug due to not urldecoded parameter

### DIFF
--- a/start.php
+++ b/start.php
@@ -333,7 +333,7 @@ function plugins_page_handler($page) {
 			} 
 			
 			set_input('guid', $page[0]);
-			set_input('version', $page[1]);					
+			set_input('version', urldecode($page[1]));
 			
 			include "$pages_dir/view.php";
 			break;			


### PR DESCRIPTION
That fix works, but I don't think we should end up doing such fixes. Looks like params were decoded in 1.8 and that changed in 1.9
