### PR TITLE
Enhances thumbail handling

### DIFF
--- a/image.php
+++ b/image.php
@@ -1,22 +1,24 @@
 <?php
 /**
  * Serve plugin project images
- *
- * This hasn't been moved into the page directory because we may want to skip
- * loading the entire engine for each image.
  */
 
-require_once(dirname(dirname(dirname(__FILE__))) . '/engine/start.php');
+// This allows adding the plugin in mod/ using a symbolic link
+$filepath = $_SERVER['SCRIPT_FILENAME'];
 
-$guid = (int)get_input("guid");
+$elgg_root = dirname(dirname(dirname($filepath)));
 
-$image = get_entity($guid);
-if (!$image) {
-	exit;
-}
+require_once("{$elgg_root}/engine/settings.php");
+require_once("{$elgg_root}/engine/classes/Elgg/EntityDirLocator.php");
 
-$filename = $image->originalfilename;
-$filelocation = $image->getFilenameOnFilestore();
+$owner_guid = (int) $_GET['owner_guid'];
+$filename = $_GET['name'];
+
+$locator = new Elgg_EntityDirLocator($owner_guid);
+$path = $locator->getPath();
+
+$filelocation = "{$CONFIG->dataroot}{$path}plugins/$filename";
+
 $size = @filesize($filelocation);
 header("Content-Disposition: inline; filename=\"$filename\"");
 header("Content-type: image/jpeg");
@@ -26,4 +28,3 @@ header("Cache-Control: public");
 header("Content-Length: $size");
 readfile($filelocation);
 exit;
-

--- a/start.php
+++ b/start.php
@@ -49,9 +49,6 @@ function plugins_init() {
 	// Register a page handler, so we can have nice URLs
 	elgg_register_page_handler('plugins', 'plugins_page_handler');
 
-	// Image handler
-	elgg_register_page_handler('plugins_image', 'plugins_image_page_handler');
-
 	// Tell core to send notifications when new projects and releases are created
 	elgg_register_notification_event('object', 'plugin_project', array('create'));
 	elgg_register_notification_event('object', 'plugin_release', array('create'));
@@ -318,10 +315,6 @@ function plugins_page_handler($page) {
 			set_input('guid', $page[1]);
 			include("$pages_dir/contributors.php");
 			break;
-		case "icon":
-			set_input('guid', $page[1]);
-			include(dirname(__FILE__) . '/image.php');
-			break;
 		default:
 			if (!isset($page[0])) {
 				// /plugins is the main page
@@ -347,40 +340,6 @@ function plugins_page_handler($page) {
 	}
 
 	return TRUE;
-}
-
-/**
- * Serve up image.
- *
- * @param unknown_type $page
- * @return unknown_type
- */
-function plugins_image_page_handler($page) {
-	// fileguid/createtime.jpg
-	if (!is_array($page) || !array_key_exists(0, $page) || !array_key_exists(1, $page)) {
-		exit;
-	}
-
-	if (!($file = get_entity($page[0])) || !($file instanceof ElggFile)
-	|| !($time = str_replace('.jpg', '', strtolower($page[1])))
-	|| ($file->time_created != $time)) {
-		exit;
-	}
-
-	$contents = $file->grabFile();
-	header('Expires: ' . date('r', time() + 60*60*24*7));
-	header('Pragma: public');
-	header('Cache-Control: public');
-	header("Content-Disposition: inline; filename=\"{$file->originalfilename}\"");
-	header("Content-type: {$file->getMimeType()}");
-	header("Content-Length: " . strlen($contents));
-
-	$split_output = str_split($contents, 1024);
-	foreach($split_output as $chunk) {
-		echo $chunk;
-	}
-
-	exit;
 }
 
 /**

--- a/views/default/object/plugin_project/screenshots.php
+++ b/views/default/object/plugin_project/screenshots.php
@@ -12,29 +12,49 @@ $project = $vars['entity'];
 // ordering by guid does not guarantee the correct order
 $img_files = $project->getScreenshots();
 
-echo '<ul class="elgg-gallery elgg-plugin-screenshots float-alt">';
+$thumbnails = '';
 foreach ($img_files as $file) {
 	$thumb = get_entity($file->thumbnail_guid);
 	if (!$thumb) {
 		continue;
 	}
 
-	$src = elgg_get_site_url() . "plugins/icon/{$thumb->getGUID()}/icon.jpg";
-	$link = elgg_get_site_url() . "plugins/icon/{$file->getGUID()}/icon.jpg";
+	$path_parts = pathinfo($file->getFilenameOnFilestore());
+	$image_name = $path_parts['basename'];
+	$link = "mod/community_plugins/image.php?&owner_guid={$file->owner_guid}&name={$image_name}";
 
-	echo "<li>";
-	echo "<a class=\"elgg-plugin-screenshot elgg-lightbox\" href=\"$link\" rel=\"plugins-gallery\"><img src=\"$src\" alt=\"$file->title\" title=\"$file->title\" height=\"60\" width=\"60\"/></a>";
+	$path_parts = pathinfo($thumb->getFilenameOnFilestore());
+	$thumb_name = $path_parts['basename'];
 
+	$img = elgg_view('output/img', array(
+		'src' => "mod/community_plugins/image.php?&owner_guid={$thumb->owner_guid}&name={$thumb_name}",
+		'alt' => $file->title,
+		'title' => $file->title,
+		'width' => '60',
+		'height' => '60',
+	));
+
+	$thumbnail = elgg_view('output/url', array(
+		'href' => $link,
+		'text' => $img,
+		'rel' => 'plugins-gallery',
+		'class' => 'elgg-plugin-screenshot elgg-lightbox',
+	));
+
+	$delete_link = '';
 	if ($project->canEdit()) {
-		echo "<br/>";
 		$url = "/action/plugins/delete_project_image?project_guid={$project->getGUID()}&image_guid={$file->getGUID()}";
-		$url = elgg_add_action_tokens_to_url($url);
-		echo elgg_view('output/confirmlink', array(
-				'href' => $url,
-				'text' => 'delete',
-				'confirm' => elgg_echo("plugins:delete_project_image:confirm"),
+
+		$delete_link = elgg_view('output/confirmlink', array(
+			'href' => $url,
+			'text' => 'delete',
+			'confirm' => elgg_echo("plugins:delete_project_image:confirm"),
+			'is_action' => true,
+			'style' => 'display: block;',
 		));
 	}
-	echo "</li>";
+
+	$thumbnails .= "<li>{$thumbnail}{$delete_link}</li>";
 }
-echo '</ul>';
+
+echo "<ul class=\"elgg-gallery elgg-plugin-screenshots float-alt\">$thumbnails</ul>";

--- a/views/default/plugins/forms/project_details_segment.php
+++ b/views/default/plugins/forms/project_details_segment.php
@@ -204,27 +204,35 @@ if (array_key_exists('project', $vars)
 				$options = array(
 					'relationship_guid' => $project->getGUID(),
 					'relationship' => 'image',
-					'metadata_name_value_pair' => array('name' => 'project_image', 'value' => "$i")
+					'metadata_name_value_pair' => array(
+						'name' => 'project_image',
+						'value' => "$i",
+					)
 				);
 
-				if (($image = elgg_get_entities_from_relationship($options))
-					&& ($image[0] instanceof ElggFile)
-					&& ($thumb = get_entity($image[0]->thumbnail_guid))
-					&& ($thumb instanceof ElggFile)) {
+				$image = elgg_get_entities_from_relationship($options);
 
-					$title = $image[0]->title;
-					$src = elgg_get_site_url() . "plugins_image/{$thumb->getGUID()}/{$thumb->time_created}.jpg";
-					$img = "<img style=\"float: left; padding-right: 1em;\" src=\"$src\" />\n";
-					echo $img;
-				} else {
-					$img = $title = '';
+				if ($image && $image[0] instanceof ElggFile) {
+					$file = $image[0];
+
+					$thumb = get_entity($file->thumbnail_guid);
+
+					if ($thumb instanceof ElggFile) {
+						$img = elgg_view('output/img', array(
+							'src' => "mod/community_plugins/image.php?owner_guid={$project->owner_guid}&name={$project->guid}_image_{$i}_thumb.jpg",
+							'style' => "float: left; padding-right: 1em;",
+							'title' => $file->title
+						));
+
+						echo $img;
+					}
 				}
 			}
 
 			echo "<label>" . elgg_echo('plugins:desc') . " $i "
 			. elgg_view('input/text', array(
 				'name' => "image_{$i}_desc",
-				'value' => $sticky_values["image_{$i}_desc"] ? $sticky_values["image_{$i}_desc"] : $title,
+				'value' => isset($sticky_values["image_{$i}_desc"]) ? $sticky_values["image_{$i}_desc"] : '',
 				'style' => 'width: 25em;',
 			))
 			. '</label><br />'


### PR DESCRIPTION
I did the mistake of taking a look at the thumbnail code and simply couldn't help doing at least some refactoring to make it a bit less terrible:
- Removes duplicate image handling code
- Serves the images without loading the engine
- Makes the code more readable

What do you think of the approach in `image.php`?

BTW, we allow users to define `access_id` for the plugins, so should the images also respect it? I find it tempting to serve the images without checking the read access in `image.php`.
