### PR TITLE
Fixes #75 - move the release files on the file system

### DIFF
--- a/actions/plugins/admin/combine.php
+++ b/actions/plugins/admin/combine.php
@@ -17,6 +17,15 @@ if (!($old_project instanceof PluginProject) ||
 
 $old_name = $old_project->title;
 
+// delete old screenshots to clear up filesystem
+// note this needs to happen before $new_project->moveFilesOnSystem()
+$old_screenshots = $old_project->getScreenshots();
+if ($old_screenshots) {
+	foreach ($old_screenshots as $s) {
+		$s->delete();
+	}
+}
+
 // move releases for the old project to the new project
 $params = array(
 	'types' => 'object',
@@ -25,9 +34,38 @@ $params = array(
 	'limit' => 0,
 );
 $releases = elgg_get_entities($params);
+
+$new_releases = elgg_get_entities(array_merge($params, array('container_guids' => $new_project->guid, 'limit' => 1)));
+$new_releases_name = '';
+if ($new_releases) {
+	$info = pathinfo($new_releases[0]->originalfilename);
+	$new_releases_name =  $info['filename'];
+}
+
 foreach ($releases as $release) {
+	// append suffix on duplicate release versions
+	$dupe = $new_project->getReleaseFromVersion($release->version);
+	if ($dupe) {
+		$release->version = $release->version . '-old';
+	}
+	
+	$new_project->moveFilesOnSystem($release, $new_project->guid);
+	$release->owner_guid = $new_project->guid;
 	$release->container_guid = $new_project->guid;
 	$release->save();
+	
+	if ($new_releases_name) {
+		$prefix = "plugins/";
+		// update file names on the filestore
+		$oldname = $release->getFilenameOnFilestore();
+		$info = pathinfo($oldname);
+		
+		$new_file_name = $new_releases_name . '.' . $info['extension'];
+		$release->setFilename($prefix . strtolower($release->time_created . $new_file_name));
+		$release->originalfilename = $new_file_name;
+		$newname = $release->getFilenameOnFilestore();
+		rename($oldname, $newname);
+	}
 }
 
 // move download count to new project
@@ -42,5 +80,5 @@ if ($annotation_name) {
 
 $old_project->delete();
 
-system_message(elgg_echo('plugins:action:combine:success'));
+system_message(elgg_echo('plugins:action:combine:success', array($old_guid, $new_guid)));
 forward(REFERER);

--- a/actions/plugins/admin/transfer.php
+++ b/actions/plugins/admin/transfer.php
@@ -7,13 +7,13 @@ $members = get_input('members');
 $recipient = get_user($members[0]);
 
 if (!$project || !$project->canEdit() || !elgg_instanceof($project, 'object', 'plugin_project')) {
-  register_error(elgg_echo('plugins:action:invalid_project'));
-  forward(REFERER);
+	register_error(elgg_echo('plugins:action:invalid_project'));
+	forward(REFERER);
 }
 
 if (!$recipient || $recipient->isBanned() || $recipient->getGUID() == $project->owner_guid) {
-  register_error(elgg_echo('plugins:action:transfer:invalid_recipient'));
-  forward(REFERER);
+	register_error(elgg_echo('plugins:action:transfer:invalid_recipient'));
+	forward(REFERER);
 }
 
 //get all releases associated with the project
@@ -25,12 +25,6 @@ $releases = elgg_get_entities(array(
 ));
 
 $ia = elgg_set_ignore_access(true);
-
-// change owner for all releases
-foreach ($releases as $release) {
-  $release->owner_guid = $recipient->getGUID();
-  $release->save();
-}
 
 // change owner for the whole project
 $project->owner_guid = $recipient->getGUID();

--- a/actions/plugins/create_release.php
+++ b/actions/plugins/create_release.php
@@ -63,6 +63,7 @@ $release->setFilename($filestorename);
 $release->setMimetype($mimetype);
 $release->originalfilename = $_FILES['upload']['name'];
 $release->access_id = $access_id;
+$release->owner_guid = $plugin_project->getGUID();
 $release->container_guid = $plugin_project->getGUID();
 $release->version = $version;
 $release->release_notes = $release_notes;

--- a/languages/en.php
+++ b/languages/en.php
@@ -410,7 +410,7 @@ general project details, visit the edit section of the project page.',
 	'plugins:action:invalid_user' => "Invalid user",
 	'plugins:action:delete_contributor:success' => 'User has been removed from the contributors list',
 	'plugins:action:invalid_access' => 'Unknown or insufficient access to release',
-
+	'plugins:action:transfer:not_moved' => "Release ID: %s - the file could not be moved on the file system",
 );
 
 add_translation("en", $english);

--- a/lib/upgrades.php
+++ b/lib/upgrades.php
@@ -1,0 +1,49 @@
+<?php
+
+function plugins_upgrade_20141107() {
+	$options = array(
+		'type' => 'object',
+		'subtype' => 'plugin_release',
+		'limit' => false
+	);
+
+	$releases = new ElggBatch('elgg_get_entities', $options);
+
+	foreach ($releases as $release) {
+		if ($release->owner_guid != $release->container_guid) {
+			
+			PluginProject::moveFilesOnSystem($release, $release->container_guid);
+			$release->owner_guid = $release->container_guid;
+			$release->save();
+		}
+	}
+
+	// move screenshots
+	$options = array(
+		'type' => 'object',
+		'subtype' => 'plugin_project',
+		'limit' => false
+	);
+
+	$plugins = new ElggBatch('elgg_get_entities', $options);
+
+	foreach ($plugins as $p) {
+		$screenshots = $p->getScreenshots();
+
+		foreach ($screenshots as $s) {
+			if ($s->owner_guid != $p->guid) {
+				$thumb = get_entity($s->thumbnail_guid);
+				
+				if ($thumb) {
+					$p->moveFilesOnSystem($thumb, $p->guid);
+					$thumb->owner_guid = $p->guid;
+					$thumb->save();
+				}
+
+				$p->moveFilesOnSystem($s, $p->guid);
+				$s->owner_guid = $p->guid;
+				$s->save();
+			}
+		}
+	}
+}


### PR DESCRIPTION
- [x] Upgrade script for relocating files to project ID directories
- [x] Migrate also the plugin screenshots
- [x] Squash the "remove debugging code" commit
- [x] Remove `/5000/<user_guid>/plugins/` dir after upgrade if empty
- [x] Test the upgrade on copy of community data
- [x] Decide whether to move or delete project images when combining two projects
  - Currently they get removed when calling `$old_project->delete();`
  - Currently the `plugins/` dir also gets left behind because it still contains the screenshots when calling `rmdir()`
- [x] Find out if it's possible to easily change the release filename when combining
  - After combining plugin **foo** into plugin **bar** you would assume that the moved releases would be named **bar.zip** when you download them. The zip packages are however still named **foo.zip**
- [x] Update the commit message to better describe what the commit does
