### PR TITLE
chore(routing): Redirect handlers now return the new URL

### DIFF
--- a/lib/page_handlers.php
+++ b/lib/page_handlers.php
@@ -14,7 +14,7 @@ function plugins_page_handler($segments) {
 		"plugins/edit" => "/plugins/{plugin}/edit",
 		"plugins/icon" => "/plugins/{plugin}/icons/{icon}.jpg",
 		"plugins/index" => "/plugins",
-		"plugins/list/{type}",
+		"plugins/list" => "/plugins/list/{type}",
 		"plugins/new" => "/plugins/new",
 		"plugins/search" => "/plugins/search",
 		"plugins/transfer" => "/plugins/{plugin}/transfer",
@@ -32,90 +32,85 @@ function plugins_page_handler($segments) {
 
 	$forwards = array(
 		"/plugins/all" => function() {
-			forward("/plugins");
+			return "/plugins";
 		},
 		"/plugins/category/{category}" => function() {
 			$category = get_input('category');
-			forward("/plugins/search?category=$category");
+			return "/plugins/search?category=$category";
 		},
 		"/plugins/contributors/{plugin}" => function() {
 			$plugin = get_input('plugin');
-			forward("/plugins/$plugin/contributors");
+			return "/plugins/$plugin/contributors";
 		},
 		"/plugins/developer/{developer}" => function() {
 			$developer = get_input('developer');
-			forward("/plugins/search?owner=$developer");
+			return "/plugins/search?owner=$developer";
 		},
 		"/plugins/developer/{developer}/type/{type}" => function() {
 			$developer = get_input('developer');
 			$type = get_input('type');
-			forward("/plugins/search?owner=$developer&type=$type");
+			return "/plugins/search?owner=$developer&type=$type";
 		},
 		"/plugins/download/{release}" => function() {
 			$release = get_entity(get_input('release'));
 			$plugin = $release->getProject();
-			forward("/plugins/{$plugin->guid}/releases/{$release->guid}/download");
+			return "/plugins/{$plugin->guid}/releases/{$release->guid}/download";
 		},
 		"/plugins/edit/project/{plugin}" => function() {
 			$plugin = get_input('plugin');
-			forward("/plugins/$plugin/edit");
+			return "/plugins/$plugin/edit";
 		},
 		"/plugins/edit/release/{release}" => function() {
 			$release = get_entity(get_input('release'));
 			$plugin = $release->getProject();
-			forward("/plugins/{$plugin->guid}/releases/{$release->guid}/edit");
+			return "/plugins/{$plugin->guid}/releases/{$release->guid}/edit";
 		},
 		"/plugins/icon/{guid}/icon.jpg" => function() {
 			$icon = get_input('guid');
 			$plugin = get_entity($icon)->getContainerGuid();
-			forward("/plugins/$plugin/icons/$icon.jpg");
+			return "/plugins/$plugin/icons/$icon.jpg";
 		},
 		"/plugins/new/project/{username}" => function() {
-			forward("/plugins/new");
+			return "/plugins/new";
 		},
 		"/plugins/new/release/{plugin}" => function() {
 			$plugin = get_input('plugin');
-			forward("/plugins/$plugin/releases/new");
+			return "/plugins/$plugin/releases/new";
 		},
 		"/plugins/project/{plugin}" => function() {
 			$plugin = get_input('plugin');
-			forward("/plugins/$plugin");
+			return "/plugins/$plugin";
 		},
 		"/plugins/release/{release}" => function() {
 			$release = get_entity(get_input('release'));
 			$plugin = $release->getProject();
-			forward("/plugins/{$plugin->guid}/releases/{$release->version}");
+			return "/plugins/{$plugin->guid}/releases/{$release->version}";
 		},
 		"/plugins/transfer/{plugin}" => function() {
 			$plugin = get_input('plugin');
-			forward("/plugins/$plugin/transfer");
-		},
-		"/plugins/list/{type}" => function() {
-			
-			include dirname(__DIR__) . '/pages/plugins/list.php';
-			return true;
+			return "/plugins/$plugin/transfer";
 		},
 		"/plugins/{guid}/{release}/{title}" => function() {
 			$plugin = get_input('guid');
 			$release = get_input('release');
 
-			forward("/plugins/$plugin/releases/$release");
+			return "/plugins/$plugin/releases/$release";
 		},
 		"/plugins/{guid}/{release}" => function() {
 			$plugin = get_input('guid');
 			$release = get_input('release');
 
-			forward("/plugins/$plugin/releases/$release");
+			return "/plugins/$plugin/releases/$release";
 		},
 		"/plugins/{username}/read/{plugin}/{title}" => function() {
 			$plugin = get_input('plugin');
-			forward("/plugins/$plugin");
+			return "/plugins/$plugin";
 		},
 		"/plugins_image/{guid}/{timestamp}.jpg" => function() {
 			$screenshot = get_entity(get_input('guid'));
 			$plugin = $screenshot->getContainerEntity();
 			$timestamp = $screenshot->time_created;
-			forward("/plugins/$plugin/screenshots/$screenshot.$timestamp.jpg");
+			return "/plugins/$plugin/screenshots/$screenshot.$timestamp.jpg";
 		},
 	);
 
@@ -149,7 +144,7 @@ function plugins_page_handler($segments) {
 				set_input($name, $value);
 			}
 
-			$callback();
+			forward($callback());
 			return true;
 		}
 	}


### PR DESCRIPTION
Instead of explicitly calling `forward()`, which reduces flexibility.
E.g. now we are free to do an "internal" redirect instead of sending
the redirect all the way back to the browser.

Fixes #105 
