### PR TITLE
fix(activate): Creating the table now uses update_data, not get_data

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -23,4 +23,4 @@ $sql = "CREATE TABLE IF NOT EXISTS `{$db_prefix}plugin_downloads` (
 	KEY `downloads` (`downloads`)
 ) ENGINE=MyISAM";
 
-get_data($sql);
+update_data($sql);


### PR DESCRIPTION
Previous implementation caused an exception in Elgg 2.0 (appropriately so!).